### PR TITLE
Remove insights-proxy instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,7 @@
 # Pinakes UI
 [![Dist release](https://github.com/ansible/pinakes-ui/actions/workflows/dist-release.yml/badge.svg)](https://github.com/ansible/pinakes-ui/actions/workflows/dist-release.yml)
 
-## Running locally
-Have [insights-proxy](https://github.com/RedHatInsights/insights-proxy) installed under PROXY_PATH
-
-```shell
-SPANDX_CONFIG="profiles/local-frontends.js" bash ../insights-proxy/scripts/run.sh
-```
-
-## Running the standalone Pinakes UI 
+## Running the standalone Pinakes UI
 1. Clone the [Pinakes](https://github.com/ansible/pinakes) repo and follow the instructions for starting up the API.
 2. Install node
 3. `npm install`


### PR DESCRIPTION
Since we no longer use the insights-proxy piece to run the UI locally, I've removed the instructions from the README