### PR TITLE
Update README to include custom building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@
 4. `npm run start:standalone`
 
 
+## Building the Pinakes UI for use with Pinakes
+
+This is useful if you would like to build the UI with custom images within `src/assets/images` (override these images before executing these build steps):
+
+First, our Approval UI is currently a separate repository. We are working on integrating this repository into pinakes-ui, so these steps will change to no longer include mentions of approval-ui in the near future.
+
+Ensure you are in the top level directory of the pinakes-ui project.
+`git clone https://github.com/RedHatInsights/approval-ui.git`
+
+```
+npm ci || npm install
+npm run build:standalone
+cd ./approval-ui
+npm ci || npm install
+npm run build:standalone
+cd ..
+cp -r ./approval-ui/dist ./dist/approval
+tar -C dist/ -czvf catalog-ui.tar.gz .
+```
+
+
 ## License
 
 This project is available as open source under the terms of the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
Since https://github.com/ansible/pinakes/pull/484 now exists, we need this information here so that if users want to replace the entire .tar.gz file, they know how to have custom images while doing so.