### PR TITLE
[SSP-2986] Updated workflow endpoints to match the updated backend

### DIFF
--- a/src/forms/approval-name-async-validator.js
+++ b/src/forms/approval-name-async-validator.js
@@ -2,15 +2,18 @@ import { fetchWorkflowByName } from '../helpers/workflow/workflow-helper';
 import asyncDebounce from '../utilities/async-form-validator';
 import formMessages from '../messages/form.messages';
 
-const validateName = (name, id, intl) =>
-  fetchWorkflowByName(name).then(({ data }) => {
-    const workflow = id
-      ? data.find((wf) => name === wf.name && id !== wf.id)
-      : data.find((wf) => name === wf.name);
+const validateName = (name, id, intl) => {
+  return name
+    ? fetchWorkflowByName(name).then(({ data }) => {
+        const workflow = id
+          ? data.find((wf) => name === wf.name && id !== wf.id)
+          : data.find((wf) => name === wf.name);
 
-    if (workflow) {
-      throw intl.formatMessage(formMessages.nameTaken);
-    }
-  });
+        if (workflow) {
+          throw intl.formatMessage(formMessages.nameTaken);
+        }
+      })
+    : true;
+};
 
 export default asyncDebounce(validateName);

--- a/src/helpers/template/template-helper.js
+++ b/src/helpers/template/template-helper.js
@@ -14,7 +14,7 @@ export function fetchTemplates(filter = '', pagination = defaultSettings) {
 }
 
 export const fetchTemplatesOptions = (filterValue) => {
-  const filterQuery = `?search=${filterValue}`;
+  const filterQuery = `?name=${filterValue}`;
   return getAxiosInstance()
     .get(
       `${APPROVAL_API_BASE}/templates/${

--- a/src/helpers/workflow/workflow-helper.js
+++ b/src/helpers/workflow/workflow-helper.js
@@ -22,14 +22,14 @@ export let fetchWorkflowByName = (name) =>
 
 export function updateWorkflow(data) {
   return getAxiosInstance().patch(
-    `${APPROVAL_API_BASE}/workflows/${data.id}`,
+    `${APPROVAL_API_BASE}/workflows/${data.id}/`,
     data
   );
 }
 
 export function repositionWorkflow(data) {
   return getAxiosInstance().patch(
-    `${APPROVAL_API_BASE}/workflows/${data.id}`,
+    `${APPROVAL_API_BASE}/workflows/${data.id}/`,
     data.sequence
   );
 }
@@ -38,10 +38,7 @@ export const listTemplates = () =>
   getAxiosInstance().get(`${APPROVAL_API_BASE}/templates/`);
 
 export function addWorkflowToTemplate(templateId, workflow) {
-  return getAxiosInstance().post(
-    `${APPROVAL_API_BASE}/templates/${templateId}/workflows/`,
-    workflow
-  );
+  return getAxiosInstance().post(`${APPROVAL_API_BASE}/workflows/`, workflow);
 }
 
 export function addWorkflow(workflow) {

--- a/src/helpers/workflow/workflow-helper.js
+++ b/src/helpers/workflow/workflow-helper.js
@@ -7,7 +7,7 @@ export function fetchWorkflows(filter = '', pagination = defaultSettings) {
     pagination.limit,
     10
   )}&page=${pagination.offset || 1}`;
-  const filterQuery = `&name=${filter}`;
+  const filterQuery = `&search=${filter}`;
 
   return getAxiosInstance().get(
     `${APPROVAL_API_BASE}/workflows/?${filterQuery}${paginationQuery}`
@@ -18,7 +18,7 @@ export const fetchWorkflow = (id) =>
   getAxiosInstance().get(`${APPROVAL_API_BASE}/workflows/${id}/`);
 
 export let fetchWorkflowByName = (name) =>
-  getAxiosInstance().get(`${APPROVAL_API_BASE}/workflows/?name=${name}`);
+  getAxiosInstance().get(`${APPROVAL_API_BASE}/workflows/?search=${name}`);
 
 export function updateWorkflow(data) {
   return getAxiosInstance().patch(

--- a/src/smart-components/workflow/add-workflow-modal.js
+++ b/src/smart-components/workflow/add-workflow-modal.js
@@ -35,12 +35,10 @@ const AddWorkflow = ({ postMethod, pagination = defaultSettings }) => {
   });
 
   useEffect(() => {
-    listTemplates().then((data) =>
-      stateDispatch({
-        type: 'loaded',
-        schema: addWorkflowSchema(intl, data.data)
-      })
-    );
+    stateDispatch({
+      type: 'loaded',
+      schema: addWorkflowSchema(intl)
+    });
   }, []);
 
   const onSave = ({ group_refs = [], ...values }) => {

--- a/src/test/smart-components/template/templates.test.js
+++ b/src/test/smart-components/template/templates.test.js
@@ -228,16 +228,14 @@ describe('<Templates />', () => {
     mockApi
       .onGet(`${APPROVAL_API_BASE}/templates/?&title=&page_size=50&page=1`)
       .replyOnce({
-        body: {
-          data: [
-            {
-              id: 'edit-id',
-              name: 'foo',
-              group_refs: [{ name: 'group-1', uuid: 'some-uuid' }],
-              group_names: ['group-name-1']
-            }
-          ]
-        }
+        data: [
+          {
+            id: 'edit-id',
+            name: 'foo',
+            group_refs: [{ name: 'group-1', uuid: 'some-uuid' }],
+            group_names: ['group-name-1']
+          }
+        ]
       });
 
     mockApi

--- a/src/test/smart-components/workflow/modals/add-workflow-modal-s.test.js
+++ b/src/test/smart-components/workflow/modals/add-workflow-modal-s.test.js
@@ -18,6 +18,9 @@ import { mockApi } from '../../../../helpers/shared/__mocks__/user-login';
 describe('<AddWorkflow />', () => {
   let initialProps;
   let initialState;
+  let workflow;
+  let wrapper;
+
   const middlewares = [thunk, promiseMiddleware, notificationsMiddleware()];
   let mockStore;
   const ComponentWrapper = ({ store, children }) => (
@@ -38,16 +41,36 @@ describe('<AddWorkflow />', () => {
     localStorage.setItem('user', 'testUser');
     initialProps = {
       id: '123',
-      postMethod: jest.fn(),
       handleChange: jest.fn()
     };
-    initialState = {};
+
+    initialState = {
+      workflowReducer: {
+        workflows: {
+          data: []
+        }
+      }
+    };
+
+    workflow = {
+      name: 'Foo',
+      id: '123',
+      template: 'templateid',
+      description: 'description',
+      group_refs: [
+        {
+          uuid: '123',
+          name: 'SampleWorkflow'
+        }
+      ]
+    };
+
     mockStore = configureStore(middlewares);
   });
 
   afterEach(() => {
-    global.localStorage.setItem('catalog_standalone', false);
-    global.localStorage.removeItem('user');
+    localStorage.setItem('catalog_standalone', false);
+    localStorage.removeItem('user');
   });
 
   it('should close the form', async () => {
@@ -85,6 +108,141 @@ describe('<AddWorkflow />', () => {
         .simulate('click');
     });
     wrapper.update();
+    expect(
+      wrapper.find(MemoryRouter).instance().history.location.pathname
+    ).toEqual(routes.workflows.index);
+  });
+
+  it('should fetch data from api and submit the form', async () => {
+    mockApi
+      .onGet(`${APPROVAL_API_BASE}/templates/`)
+      .replyOnce(200, [{ id: 'templateid', title: 'name' }]);
+
+    mockApi
+      .onGet(`${APPROVAL_API_BASE}/templates/?search=template`)
+      .replyOnce(200, [{ id: 'templateid', title: 'name' }]);
+
+    mockApi.onGet(`${APPROVAL_API_BASE}/workflows/123/`).replyOnce(200, {
+      name: 'Foo',
+      id: '123',
+      template: 'templateid',
+      description: 'description',
+      group_refs: [
+        {
+          uuid: '123',
+          name: 'SampleWorkflow'
+        }
+      ]
+    });
+    mockApi.onGet(`${APPROVAL_API_BASE}/workflows/?&name=Foo`).replyOnce(200, {
+      name: 'Foo',
+      id: '123',
+      template: 'templateid',
+      description: 'description',
+      group_refs: [
+        {
+          uuid: '123',
+          name: 'SampleWorkflow'
+        }
+      ]
+    });
+    mockApi
+      .onGet(`${APPROVAL_API_BASE}/templates/`)
+      .replyOnce(200, { data: [{ id: 'templateid', title: 'name' }] });
+
+    expect.assertions(6);
+
+    wfHelper.fetchWorkflowByName = jest
+      .fn()
+      .mockImplementationOnce((value) => {
+        expect(value).toEqual('some-name');
+
+        return Promise.resolve({
+          data: []
+        });
+      })
+      .mockImplementationOnce((value) => {
+        expect(value).toEqual('some-name');
+
+        return Promise.resolve({
+          data: []
+        });
+      });
+
+    mockApi
+      .onGet(`${APPROVAL_API_BASE}/groups/?role=approval-approver`)
+      .replyOnce(200, { data: [{ id: 'id', name: 'name' }] });
+
+    jest.useFakeTimers();
+
+    const store = mockStore(initialState);
+
+    await act(async () => {
+      wrapper = mount(
+        <ComponentWrapper store={store}>
+          <Route
+            path="/workflows/add-workflow"
+            render={() => <AddWorkflow {...initialProps} />}
+          />
+        </ComponentWrapper>
+      );
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.update();
+    });
+
+    expect(
+      wrapper
+        .find('input')
+        .first()
+        .props().value
+    ).toEqual('');
+    expect(
+      wrapper
+        .find('textarea')
+        .first()
+        .props().value
+    ).toEqual('');
+
+    await act(async () => {
+      const name = wrapper.find('input').first();
+      name.instance().value = 'some-name';
+      name.simulate('change');
+    });
+    wrapper.update();
+
+    await act(async () => {
+      jest.advanceTimersByTime(550); // name async validation
+      jest.useRealTimers();
+    });
+    wrapper.update();
+
+    await act(async () => {
+      const description = wrapper.find('textarea').first();
+      description.instance().value = 'some-description';
+      description.simulate('change');
+    });
+    wrapper.update();
+
+    wfHelper.addWorkflow = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve('ok'));
+
+    expect(wfHelper.addWorkflow).not.toHaveBeenCalled();
+
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+    });
+    wrapper.update();
+
+    expect(wfHelper.addWorkflow).toHaveBeenCalledWith({
+      name: 'some-name',
+      description: 'some-description',
+      group_refs: []
+    });
+
     expect(
       wrapper.find(MemoryRouter).instance().history.location.pathname
     ).toEqual(routes.workflows.index);


### PR DESCRIPTION
Updated workflow endpoints to match the updated backend.

The endpoints have been changed from /templates/<id>/workflow to /workflows/

Also fixes the unnecessary "https://localhost:8443/api/pinakes/v1/workflows/?name=undefined" - part of https://issues.redhat.com/browse/SSP-2943

Also fixes https://issues.redhat.com/browse/SSP-2998
 - Adds missing trailing slash to the .workflows<id> patch endpoint