### PR TITLE
[SSP-2997] Fix for notification settings patch payload

### DIFF
--- a/src/helpers/notification/notification-helper.js
+++ b/src/helpers/notification/notification-helper.js
@@ -26,7 +26,7 @@ export let fetchNotificationSettingByName = (name) =>
 
 export function updateNotificationSetting(data) {
   return getAxiosInstance().patch(
-    `${APPROVAL_API_BASE}/notifications_settings/${data.id}`,
+    `${APPROVAL_API_BASE}/notifications_settings/${data.id}/`,
     data
   );
 }

--- a/src/smart-components/notification-settings/edit-notification-setting-modal.js
+++ b/src/smart-components/notification-settings/edit-notification-setting-modal.js
@@ -79,12 +79,17 @@ const EditNotificationSetting = ({
 
   const onCancel = () => push(routes.notifications.index);
 
-  const onSave = ({ description = '', ...values }) => {
+  const onSave = (values) => {
     onCancel();
+    const { id, name, notification_type, settings, ...newSettings } = {
+      ...values
+    };
+
     const notificationSettingData = {
       id,
-      ...values,
-      description
+      name,
+      notification_type,
+      settings: newSettings
     };
     return dispatch(updateNotificationSetting(notificationSettingData, intl))
       .then(() => postMethod({ ...pagination }))

--- a/src/test/smart-components/notification-settings/modals/edit-notification-setting-modal.test.js
+++ b/src/test/smart-components/notification-settings/modals/edit-notification-setting-modal.test.js
@@ -135,7 +135,7 @@ describe('<EditNotificationSetting />', () => {
       wrapper = mount(
         <ComponentWrapper
           store={store}
-          initialEntries={['/notifications?notificationSetting=123']}
+          initialEntries={['/notifications/?notificationSetting=123']}
         >
           <Route
             path="/notifications"
@@ -205,7 +205,7 @@ describe('<EditNotificationSetting />', () => {
       wrapper = mount(
         <ComponentWrapper
           store={store}
-          initialEntries={['/notification-setting?notificationSetting=123']}
+          initialEntries={['/notification-setting/?notificationSetting=123']}
         >
           <Route
             path="/notification-setting"


### PR DESCRIPTION
Before - error 500 dues to incorrect payload and missing trailing slash

After:
![Screenshot from 2022-06-29 16-06-24](https://user-images.githubusercontent.com/12769982/176535355-a52921da-9660-4687-8032-4ec3170f03f3.png)
