### PR TITLE
Generic Localization Shell Scripts

### DIFF
--- a/tools/scripts/l18n/post_translation.sh
+++ b/tools/scripts/l18n/post_translation.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+cd _clones/pinakes-ui/
+
+# Rename the zh_cn folder 
+mv translations/zh_cn translations/zh
+
+# locale will be dropped here
+pinakes_ui_path="locales" 
+
+# Copy and update the files
+rsync -av translations/ $pinakes_ui_path
+
+# Cleanup
+rm -rf translations/

--- a/tools/scripts/l18n/pre_translation.sh
+++ b/tools/scripts/l18n/pre_translation.sh
@@ -1,0 +1,8 @@
+# Change Directory to clones
+cd _clones/pinakes-ui/
+
+# Extract UI Strings
+npm run extract:messages
+
+# Move files to translations folder
+mv build/messages/messages.json translations/


### PR DESCRIPTION

We're in process of automating localization of pinakes-ui application using Ansible Memsource Collection with help of roles & playbooks.

Ref: https://github.com/ansible/ansible-collection-memsource

The requirement here is, below two scripts will be added to the path tools/scripts/l18n/
- pre_translation.sh
- post_translation.sh