### PR TITLE
Removed static path from the scripts

### DIFF
--- a/tools/scripts/l18n/post_translation.sh
+++ b/tools/scripts/l18n/post_translation.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-cd _clones/pinakes-ui/
 
 # Rename the zh_cn folder 
 mv translations/zh_cn translations/zh

--- a/tools/scripts/l18n/pre_translation.sh
+++ b/tools/scripts/l18n/pre_translation.sh
@@ -1,5 +1,4 @@
-# Change Directory to clones
-cd _clones/pinakes-ui/
+#!/bin/bash
 
 # Extract UI Strings
 npm run extract:messages


### PR DESCRIPTION
Hello,

There is a small bug fix of removing static paths from the script which were redundant and have been removed.

Background:
The pull request is for the purpose of automating the localization of Pinakes-UI.
We're actively developing an Ansible collection for this process called as [Ansible Memsource Collection](https://github.com/ansible/ansible-collection-memsource)

The process comprises of two tasks:
- Pull Strings from the project (Using the project framework's strings extraction command). These strings (Usually retrieved are in English) are then uploaded to a third party software called Memsource
- Push Strings to the projects, once the translations are completed and the strings are ready to be pushed back to the repository, the push/ post_translation role of this collection is executed

For this process, we require two shell scripts to be placed in the repository. 
- pre_translation.sh - which performs the extraction of strings from a project. In this process, a folder called "translations" will be provided, the script ensures to move the strings to the translations folder
   - Empty translations folder -> messages.json file will be dropped here which will be uploaded to memsource.
- post_translation.sh - which performs the process of moving the strings to appropriate directory in the project, a PR is later autogenerated by the underlying Ansible role being utilized here for merging the translated strings. Again a translations folder will be provided with all the translated strings, the script would ensure to utilize the folder and move the files according to the project needs.
   - Translation folder with all languages generated files
   e.g. 
          /translations/fr/messages.json
          /translations/jp/messages.json
          /translations/ko/messages.json

  The script would move the file and overwrite the existing files by opening a PR.
  e.g.
        /translations/fr/messages.json->  Moving to /locale/fr/messages.json